### PR TITLE
Add ability to use checkedState as a BOOL without changing current use

### DIFF
--- a/Classes/M13Checkbox.h
+++ b/Classes/M13Checkbox.h
@@ -50,9 +50,9 @@ typedef enum {
 - (id)initWithTitle:(NSString *)title andHeight:(CGFloat)height;//set the frame with the specified height, width will expand to fit text
 
 - (void)setTitle:(NSString *)title;
-- (void)setState:(M13CheckboxState)state;// deprecated
+- (void)setState:(M13CheckboxState)state __attribute((deprecated("use setCheckState method"))); 
 - (void)setCheckState:(M13CheckboxState)state;//Change state programitically
-- (void)toggleState; // deprecated
+- (void)toggleState __attribute((deprecated("use toggleCheckState method")));
 - (void)toggleCheckState;
 - (void)autoFitFontToHeight;//If you change the font, run this to change the font size to fit the frame.
 - (void)autoFitWidthToText;

--- a/Classes/M13Checkbox.m
+++ b/Classes/M13Checkbox.m
@@ -313,7 +313,7 @@
     }
 }
 
-- (void)setState:(M13CheckboxState)state // deprecated
+- (void)setState:(M13CheckboxState)state __attribute((deprecated("use setCheckState method")))
 {
     [self setCheckState:state];
 }
@@ -323,7 +323,7 @@
     [checkView setNeedsDisplay];
 }
 
-- (void)toggleState // deprecated
+- (void)toggleState __attribute((deprecated("use toggleCheckState method")))
 {
     [self toggleCheckState];
 }


### PR DESCRIPTION
This big advantage for this change is that this component will now be compatible for use with KVC and KVO when data is a BOOL, which is a very common use-case.

The M13CheckboxState typedef has NO and YES values in the enum
The setState method deprecated to be replaced with setCheckedState
The toggleState method is deprecated to be replaced with toggleCheckState
The toggleCheckState method treats the checkState as a BOOL

The only behavioral change is that toggling a mixed state now results in an unchecked state
No code changes are necessary for the end developer.
