### PR TITLE
Fix retain cycle in CheckView

### DIFF
--- a/Classes/M13Checkbox.m
+++ b/Classes/M13Checkbox.m
@@ -25,7 +25,7 @@
 //Custom Checkbox View
 @interface CheckView : UIView
 
-@property (nonatomic, retain) M13Checkbox *checkbox;
+@property (nonatomic, weak) M13Checkbox *checkbox;
 @property (nonatomic, assign) BOOL selected;
 
 @end


### PR DESCRIPTION
CheckView contained a retain reference to M13Checkbox, and M13Checkbox contained a (default) strong reference to CheckView, creating a retain cycle and a memory leak (discovered this when using M13Checkbox in one of my projects!). Changing CheckView's reference to M13Checkbox to weak fixes this retain cycle.
