### PR TITLE
Use gesture recognizer for touch handling

### DIFF
--- a/Classes/M13Checkbox.m
+++ b/Classes/M13Checkbox.m
@@ -142,6 +142,7 @@
 
 - (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event
 {
+    // Override `-touchesEnded:withEvent:` to check whether the touch is outside of the M13Checkbox's bounds, and fail to recognize if so.
     UITouch *anyTouch = [touches anyObject];
     CGPoint touchPoint = [anyTouch locationInView:self.view];
     if (!CGRectContainsPoint(self.view.bounds, touchPoint))
@@ -149,6 +150,7 @@
         self.state = UIGestureRecognizerStateFailed;
     }
 
+    // If `self.state` is not yet set, the superclass implementation of this method will set it as it sees fit.
     [super touchesEnded:touches withEvent:event];
 }
 
@@ -474,7 +476,7 @@
 
 - (void)handleLongPress:(UIGestureRecognizer *)recognizer
 {
-    if (UIGestureRecognizerStateBegan == recognizer.state)
+    if (UIGestureRecognizerStateBegan == recognizer.state || UIGestureRecognizerStateChanged == recognizer.state)
     {
         checkView.selected = YES;
     }

--- a/Classes/M13Checkbox.m
+++ b/Classes/M13Checkbox.m
@@ -270,7 +270,10 @@
     //Add the subviews
     [self addSubview:checkView];
     [self addSubview:_titleLabel];
-    
+
+    UILongPressGestureRecognizer *recognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongPress:)];
+    recognizer.minimumPressDuration = 0.;
+    [self addGestureRecognizer:recognizer];
 }
 
 - (CGFloat)heightForCheckbox
@@ -435,36 +438,26 @@
     return checkView.frame;
 }
 
-#pragma mark - UIControl overrides
+#pragma mark - UIGestureRecognizer action
 
-- (BOOL)beginTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event
+- (void)handleLongPress:(UIGestureRecognizer *)recognizer
 {
-    [super beginTrackingWithTouch:touch withEvent:event];
-    checkView.selected = YES;
+    if (UIGestureRecognizerStateBegan == recognizer.state)
+    {
+        checkView.selected = YES;
+    }
+    else
+    {
+        checkView.selected = NO;
+
+        if (UIGestureRecognizerStateEnded == recognizer.state)
+        {
+            [self toggleCheckState];
+            [self sendActionsForControlEvents:UIControlEventValueChanged];
+        }
+    }
+
     [checkView setNeedsDisplay];
-    
-    return YES;
-}
-
-- (BOOL)continueTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event
-{
-    [super continueTrackingWithTouch:touch withEvent:event];
-    return YES;
-}
-
-- (void)endTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event
-{
-    checkView.selected = NO;
-    [self toggleCheckState];
-    [self sendActionsForControlEvents:UIControlEventValueChanged];
-    [super endTrackingWithTouch:touch withEvent:event];
-}
-
-- (void)cancelTrackingWithEvent:(UIEvent *)event
-{
-    checkView.selected = NO;
-    [checkView setNeedsDisplay];
-    [super cancelTrackingWithEvent:event];
 }
 
 @end

--- a/Classes/M13Checkbox.m
+++ b/Classes/M13Checkbox.m
@@ -13,6 +13,8 @@
 
 #import "M13Checkbox.h"
 
+#import <UIKit/UIGestureRecognizerSubclass.h>
+
 #define kBoxSize .875
 #define kCheckHorizontalExtention .125
 #define kCheckVerticalExtension .125
@@ -117,6 +119,37 @@
     
     //Cleanup
     CGColorSpaceRelease(colorSpace);
+}
+
+@end
+
+@interface M13GestureRecognizer : UILongPressGestureRecognizer
+
+@end
+
+@implementation M13GestureRecognizer
+
+- (instancetype)initWithTarget:(id)target action:(SEL)action
+{
+    self = [super initWithTarget:target action:action];
+    if (self)
+    {
+        self.minimumPressDuration = 0.;
+    }
+
+    return self;
+}
+
+- (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event
+{
+    UITouch *anyTouch = [touches anyObject];
+    CGPoint touchPoint = [anyTouch locationInView:self.view];
+    if (!CGRectContainsPoint(self.view.bounds, touchPoint))
+    {
+        self.state = UIGestureRecognizerStateFailed;
+    }
+
+    [super touchesEnded:touches withEvent:event];
 }
 
 @end
@@ -271,8 +304,7 @@
     [self addSubview:checkView];
     [self addSubview:_titleLabel];
 
-    UILongPressGestureRecognizer *recognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongPress:)];
-    recognizer.minimumPressDuration = 0.;
+    M13GestureRecognizer *recognizer = [[M13GestureRecognizer alloc] initWithTarget:self action:@selector(handleLongPress:)];
     [self addGestureRecognizer:recognizer];
 }
 


### PR DESCRIPTION
Intended to address #33.

[Apple's documentation on gesture recognizers](https://developer.apple.com/library/ios/documentation/EventHandling/Conceptual/EventHandlingiPhoneOS/GestureRecognizer_basics/GestureRecognizer_basics.html#//apple_ref/doc/uid/TP40009541-CH2-SW40) explains:

> A window delays the delivery of touch objects to the view so that the gesture recognizer can analyze the touch first. During the delay, if the gesture recognizer recognizes a touch gesture, then the window never delivers the touch object to the view, and also cancels any touch objects it previously sent to the view that were part of that recognized sequence.

However, because Apple's own UIControls use gesture recognizers internally, they are given an opportunity to handle the touch. This PR changes M13Checkbox to implement its touch detection with gesture recognizers, so that it is afforded the same opportunity as UIKit's UIControls to respond to touches in the face of a gesture recognizer on a superview.