### PR TITLE
Fix problem with setting state without animation

### DIFF
--- a/Sources/M13Checkbox.swift
+++ b/Sources/M13Checkbox.swift
@@ -309,7 +309,7 @@ public class M13Checkbox: UIControl {
         if animated {
             manager.animate(checkState, toState: newState)
         } else {
-            manager.resetLayersForState(checkState)
+            manager.resetLayersForState(newState)
         }
     }
     


### PR DESCRIPTION
This came up when I was using M13Checkbox in a UITableViewCell subclass. I tried to set the check state in `prepareForReuse`, and with `animation = false`.

I *think* if we're calling `resetLayersForState` to the `checkState` variable, we're just keeping it as the current `CheckState`. We want to use `newState`, right?