### PR TITLE
Add backwards compatible support for Swift < 4.2

### DIFF
--- a/M13Checkbox.xcodeproj/project.pbxproj
+++ b/M13Checkbox.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		43BDF4E51DA6751C005476B2 /* M13CheckboxRadioPathGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43BDF4E41DA6751C005476B2 /* M13CheckboxRadioPathGenerator.swift */; };
 		C8A9C7D6B9A456341E134B9F /* Pods_M13Checkbox_Demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 792FB031E2B87AC7363ACC0A /* Pods_M13Checkbox_Demo.framework */; };
 		CEAFCBF6201FC46900178C16 /* Readme.md in Resources */ = {isa = PBXBuildFile; fileRef = CEAFCBF5201FC46900178C16 /* Readme.md */; };
+		DD0DA83320F60978005720C0 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0DA83220F60978005720C0 /* SwiftSupport.swift */; };
 		EA1528991C90653D00EE5115 /* ColorCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1528981C90653D00EE5115 /* ColorCollectionViewCell.swift */; };
 		EA1528A01C907B1200EE5115 /* CollectionViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA15289F1C907B1200EE5115 /* CollectionViewLayout.swift */; };
 		EA67201A1C7D0296008054BA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA6720191C7D0296008054BA /* AppDelegate.swift */; };
@@ -86,6 +87,7 @@
 		986098FE8EE9379B59F2A8C0 /* Pods-M13Checkbox.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-M13Checkbox.debug.xcconfig"; path = "Pods/Target Support Files/Pods-M13Checkbox/Pods-M13Checkbox.debug.xcconfig"; sourceTree = "<group>"; };
 		9CD5E1DB8F346AB79E3C6430 /* Pods-M13Checkbox Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-M13Checkbox Demo.release.xcconfig"; path = "Pods/Target Support Files/Pods-M13Checkbox Demo/Pods-M13Checkbox Demo.release.xcconfig"; sourceTree = "<group>"; };
 		CEAFCBF5201FC46900178C16 /* Readme.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = Readme.md; sourceTree = "<group>"; };
+		DD0DA83220F60978005720C0 /* SwiftSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftSupport.swift; path = Sources/SwiftSupport.swift; sourceTree = SOURCE_ROOT; };
 		EA1528981C90653D00EE5115 /* ColorCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ColorCollectionViewCell.swift; path = "../M13Checkbox Demo/ColorCollectionViewCell.swift"; sourceTree = "<group>"; };
 		EA15289F1C907B1200EE5115 /* CollectionViewLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CollectionViewLayout.swift; path = "../M13Checkbox Demo/CollectionViewLayout.swift"; sourceTree = "<group>"; };
 		EA26E1E41CAC66F000ACB4F4 /* M13CheckboxBounceController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = M13CheckboxBounceController.swift; path = ../Sources/Managers/M13CheckboxBounceController.swift; sourceTree = "<group>"; };
@@ -229,13 +231,14 @@
 		EA67202D1C7D02F8008054BA /* Source */ = {
 			isa = PBXGroup;
 			children = (
-				EA67202E1C7D0349008054BA /* M13Checkbox.swift */,
-				EAD2FDA41CBD2FA400086119 /* M13CheckboxGestureRecognizer.swift */,
 				43BDF4E01DA67222005476B2 /* Animation Generator */,
 				EA26E1EC1CAEDD0800ACB4F4 /* Path Generators */,
 				EAA0983C1CA8BE7F001AAF6E /* Controllers */,
-				EA6720301C7DFC3D008054BA /* M13Checkbox+IB.swift */,
 				1746F2191F30C9D7005060B9 /* DefaultValues.swift */,
+				EA67202E1C7D0349008054BA /* M13Checkbox.swift */,
+				EA6720301C7DFC3D008054BA /* M13Checkbox+IB.swift */,
+				EAD2FDA41CBD2FA400086119 /* M13CheckboxGestureRecognizer.swift */,
+				DD0DA83220F60978005720C0 /* SwiftSupport.swift */,
 			);
 			name = Source;
 			path = M13Checkbox;
@@ -480,6 +483,7 @@
 				43242B571DA7C3CA00C6AF91 /* M13CheckboxBounceController.swift in Sources */,
 				EA96F90E1CBEB5190066C6B7 /* M13CheckboxStrokeController.swift in Sources */,
 				43242B561DA7C2CC00C6AF91 /* M13CheckboxFillController.swift in Sources */,
+				DD0DA83320F60978005720C0 /* SwiftSupport.swift in Sources */,
 				43BDF4E51DA6751C005476B2 /* M13CheckboxRadioPathGenerator.swift in Sources */,
 				434D1FF61DABB52300F5A8C8 /* M13CheckboxDisclosurePathGenerator.swift in Sources */,
 				EA96F90B1CBEB5190066C6B7 /* M13CheckboxGestureRecognizer.swift in Sources */,

--- a/Sources/M13CheckboxAnimationGenerator.swift
+++ b/Sources/M13CheckboxAnimationGenerator.swift
@@ -35,12 +35,12 @@ internal class M13CheckboxAnimationGenerator {
         if !reverse {
             animation.fromValue = 0.0
             animation.toValue = 1.0
-            animation.timingFunction = CAMediaTimingFunction(name: .easeIn)
+            animation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeIn)
         } else {
             animation.fromValue = 1.0
             animation.toValue = 0.0
             animation.beginTime = CACurrentMediaTime() + (animationDuration * 0.9)
-            animation.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            animation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeOut)
         }
         // Set animation properties.
         animation.duration = animationDuration / 10.0
@@ -95,7 +95,7 @@ internal class M13CheckboxAnimationGenerator {
         animation.duration = animationDuration
         animation.isRemovedOnCompletion = false
         animation.fillMode = CAMediaTimingFillMode.forwards
-        animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        animation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
         
         return animation
     }
@@ -131,7 +131,7 @@ internal class M13CheckboxAnimationGenerator {
         animation.toValue = toPath?.cgPath
         // Set animation properties.
         animation.duration = animationDuration
-        animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        animation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
         animation.fillMode = CAMediaTimingFillMode.forwards
         animation.isRemovedOnCompletion = false
         
@@ -183,7 +183,7 @@ internal class M13CheckboxAnimationGenerator {
         animation.isRemovedOnCompletion = false
         animation.fillMode = CAMediaTimingFillMode.forwards
         animation.duration = animationDuration
-        animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        animation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
         
         return animation
     }

--- a/Sources/Managers/M13CheckboxBounceController.swift
+++ b/Sources/Managers/M13CheckboxBounceController.swift
@@ -79,7 +79,7 @@ internal class M13CheckboxBounceController: M13CheckboxController {
         ]
         
         // Setup the unselected box layer
-        unselectedBoxLayer.lineCap = .round
+        unselectedBoxLayer.lineCap = CAShapeLayerLineCap.round
         unselectedBoxLayer.rasterizationScale = UIScreen.main.scale
         unselectedBoxLayer.shouldRasterize = true
         unselectedBoxLayer.actions = newActions
@@ -90,7 +90,7 @@ internal class M13CheckboxBounceController: M13CheckboxController {
         unselectedBoxLayer.fillColor = nil
         
         // Setup the selected box layer.
-        selectedBoxLayer.lineCap = .round
+        selectedBoxLayer.lineCap = CAShapeLayerLineCap.round
         selectedBoxLayer.rasterizationScale = UIScreen.main.scale
         selectedBoxLayer.shouldRasterize = true
         selectedBoxLayer.actions = newActions
@@ -99,8 +99,8 @@ internal class M13CheckboxBounceController: M13CheckboxController {
         selectedBoxLayer.transform = CATransform3DIdentity
         
         // Setup the checkmark layer.
-        markLayer.lineCap = .round
-        markLayer.lineJoin = .round
+        markLayer.lineCap = CAShapeLayerLineCap.round
+        markLayer.lineJoin = CAShapeLayerLineJoin.round
         markLayer.rasterizationScale = UIScreen.main.scale
         markLayer.shouldRasterize = true
         markLayer.actions = newActions

--- a/Sources/Managers/M13CheckboxDotController.swift
+++ b/Sources/Managers/M13CheckboxDotController.swift
@@ -79,7 +79,7 @@ internal class M13CheckboxDotController: M13CheckboxController {
         ]
         
         // Setup the unselected box layer
-        unselectedBoxLayer.lineCap = .round
+        unselectedBoxLayer.lineCap = CAShapeLayerLineCap.round
         unselectedBoxLayer.rasterizationScale = UIScreen.main.scale
         unselectedBoxLayer.shouldRasterize = true
         unselectedBoxLayer.actions = newActions
@@ -88,7 +88,7 @@ internal class M13CheckboxDotController: M13CheckboxController {
         unselectedBoxLayer.fillColor = nil
         
         // Setup the selected box layer.
-        selectedBoxLayer.lineCap = .round
+        selectedBoxLayer.lineCap = CAShapeLayerLineCap.round
         selectedBoxLayer.rasterizationScale = UIScreen.main.scale
         selectedBoxLayer.shouldRasterize = true
         selectedBoxLayer.actions = newActions
@@ -97,8 +97,8 @@ internal class M13CheckboxDotController: M13CheckboxController {
         selectedBoxLayer.transform = CATransform3DIdentity
         
         // Setup the checkmark layer.
-        markLayer.lineCap = .round
-        markLayer.lineJoin = .round
+        markLayer.lineCap = CAShapeLayerLineCap.round
+        markLayer.lineJoin = CAShapeLayerLineJoin.round
         markLayer.rasterizationScale = UIScreen.main.scale
         markLayer.shouldRasterize = true
         markLayer.actions = newActions

--- a/Sources/Managers/M13CheckboxExpandController.swift
+++ b/Sources/Managers/M13CheckboxExpandController.swift
@@ -79,7 +79,7 @@ internal class M13CheckboxExpandController: M13CheckboxController {
         ]
         
         // Setup the unselected box layer
-        unselectedBoxLayer.lineCap = .round
+        unselectedBoxLayer.lineCap = CAShapeLayerLineCap.round
         unselectedBoxLayer.rasterizationScale = UIScreen.main.scale
         unselectedBoxLayer.shouldRasterize = true
         unselectedBoxLayer.actions = newActions
@@ -88,7 +88,7 @@ internal class M13CheckboxExpandController: M13CheckboxController {
         unselectedBoxLayer.fillColor = nil
         
         // Setup the selected box layer.
-        selectedBoxLayer.lineCap = .round
+        selectedBoxLayer.lineCap = CAShapeLayerLineCap.round
         selectedBoxLayer.rasterizationScale = UIScreen.main.scale
         selectedBoxLayer.shouldRasterize = true
         selectedBoxLayer.actions = newActions
@@ -97,8 +97,8 @@ internal class M13CheckboxExpandController: M13CheckboxController {
         selectedBoxLayer.transform = CATransform3DIdentity
         
         // Setup the checkmark layer.
-        markLayer.lineCap = .round
-        markLayer.lineJoin = .round
+        markLayer.lineCap = CAShapeLayerLineCap.round
+        markLayer.lineJoin = CAShapeLayerLineJoin.round
         markLayer.rasterizationScale = UIScreen.main.scale
         markLayer.shouldRasterize = true
         markLayer.actions = newActions

--- a/Sources/Managers/M13CheckboxFadeController.swift
+++ b/Sources/Managers/M13CheckboxFadeController.swift
@@ -79,7 +79,7 @@ internal class M13CheckboxFadeController: M13CheckboxController {
         ]
         
         // Setup the unselected box layer
-        unselectedBoxLayer.lineCap = .round
+        unselectedBoxLayer.lineCap = CAShapeLayerLineCap.round
         unselectedBoxLayer.rasterizationScale = UIScreen.main.scale
         unselectedBoxLayer.shouldRasterize = true
         unselectedBoxLayer.actions = newActions
@@ -90,7 +90,7 @@ internal class M13CheckboxFadeController: M13CheckboxController {
         unselectedBoxLayer.fillColor = nil
         
         // Setup the selected box layer.
-        selectedBoxLayer.lineCap = .round
+        selectedBoxLayer.lineCap = CAShapeLayerLineCap.round
         selectedBoxLayer.rasterizationScale = UIScreen.main.scale
         selectedBoxLayer.shouldRasterize = true
         selectedBoxLayer.actions = newActions
@@ -99,8 +99,8 @@ internal class M13CheckboxFadeController: M13CheckboxController {
         selectedBoxLayer.transform = CATransform3DIdentity
         
         // Setup the checkmark layer.
-        markLayer.lineCap = .round
-        markLayer.lineJoin = .round
+        markLayer.lineCap = CAShapeLayerLineCap.round
+        markLayer.lineJoin = CAShapeLayerLineJoin.round
         markLayer.rasterizationScale = UIScreen.main.scale
         markLayer.shouldRasterize = true
         markLayer.actions = newActions

--- a/Sources/Managers/M13CheckboxFillController.swift
+++ b/Sources/Managers/M13CheckboxFillController.swift
@@ -57,7 +57,7 @@ internal class M13CheckboxFillController: M13CheckboxController {
         ]
         
         // Setup the unselected box layer
-        unselectedBoxLayer.lineCap = .round
+        unselectedBoxLayer.lineCap = CAShapeLayerLineCap.round
         unselectedBoxLayer.rasterizationScale = UIScreen.main.scale
         unselectedBoxLayer.shouldRasterize = true
         unselectedBoxLayer.actions = newActions
@@ -68,7 +68,7 @@ internal class M13CheckboxFillController: M13CheckboxController {
         unselectedBoxLayer.fillColor = nil
         
         // Setup the selected box layer.
-        selectedBoxLayer.lineCap = .round
+        selectedBoxLayer.lineCap = CAShapeLayerLineCap.round
         selectedBoxLayer.rasterizationScale = UIScreen.main.scale
         selectedBoxLayer.shouldRasterize = true
         selectedBoxLayer.actions = newActions
@@ -76,8 +76,8 @@ internal class M13CheckboxFillController: M13CheckboxController {
         selectedBoxLayer.transform = CATransform3DIdentity
         
         // Setup the checkmark layer.
-        markLayer.lineCap = .round
-        markLayer.lineJoin = .round
+        markLayer.lineCap = CAShapeLayerLineCap.round
+        markLayer.lineJoin = CAShapeLayerLineJoin.round
         markLayer.rasterizationScale = UIScreen.main.scale
         markLayer.shouldRasterize = true
         markLayer.actions = newActions

--- a/Sources/Managers/M13CheckboxFlatController.swift
+++ b/Sources/Managers/M13CheckboxFlatController.swift
@@ -79,7 +79,7 @@ internal class M13CheckboxFlatController: M13CheckboxController {
         ]
         
         // Setup the unselected box layer
-        unselectedBoxLayer.lineCap = .round
+        unselectedBoxLayer.lineCap = CAShapeLayerLineCap.round
         unselectedBoxLayer.rasterizationScale = UIScreen.main.scale
         unselectedBoxLayer.shouldRasterize = true
         unselectedBoxLayer.actions = newActions
@@ -88,7 +88,7 @@ internal class M13CheckboxFlatController: M13CheckboxController {
         unselectedBoxLayer.fillColor = nil
         
         // Setup the selected box layer.
-        selectedBoxLayer.lineCap = .round
+        selectedBoxLayer.lineCap = CAShapeLayerLineCap.round
         selectedBoxLayer.rasterizationScale = UIScreen.main.scale
         selectedBoxLayer.shouldRasterize = true
         selectedBoxLayer.actions = newActions
@@ -97,8 +97,8 @@ internal class M13CheckboxFlatController: M13CheckboxController {
         selectedBoxLayer.transform = CATransform3DIdentity
         
         // Setup the checkmark layer.
-        markLayer.lineCap = .round
-        markLayer.lineJoin = .round
+        markLayer.lineCap = CAShapeLayerLineCap.round
+        markLayer.lineJoin = CAShapeLayerLineJoin.round
         markLayer.rasterizationScale = UIScreen.main.scale
         markLayer.shouldRasterize = true
         markLayer.actions = newActions
@@ -128,7 +128,7 @@ internal class M13CheckboxFlatController: M13CheckboxController {
         
         if pathGenerator.pathForMark(toState) == nil && pathGenerator.pathForMark(fromState) != nil {
             let morphAnimation = animationGenerator.morphAnimation(pathGenerator.pathForMark(), toPath: pathGenerator.pathForMixedMark())
-            morphAnimation.timingFunction = CAMediaTimingFunction(name: .easeIn)
+            morphAnimation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeIn)
             let opacityAnimation = animationGenerator.opacityAnimation(true)
             
             let quickOpacityAnimation = animationGenerator.quickOpacityAnimation(true)
@@ -153,7 +153,7 @@ internal class M13CheckboxFlatController: M13CheckboxController {
             markLayer.path = pathGenerator.pathForMixedMark()?.cgPath
             
             let morphAnimation = animationGenerator.morphAnimation(pathGenerator.pathForMixedMark(), toPath: pathGenerator.pathForMark())
-            morphAnimation.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            morphAnimation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeOut)
             let opacityAnimation = animationGenerator.opacityAnimation(false)
             
             let quickOpacityAnimation = animationGenerator.quickOpacityAnimation(false)

--- a/Sources/Managers/M13CheckboxSpiralController.swift
+++ b/Sources/Managers/M13CheckboxSpiralController.swift
@@ -53,7 +53,7 @@ internal class M13CheckboxSpiralController: M13CheckboxController {
         ]
         
         // Setup the unselected box layer
-        unselectedBoxLayer.lineCap = .round
+        unselectedBoxLayer.lineCap = CAShapeLayerLineCap.round
         unselectedBoxLayer.rasterizationScale = UIScreen.main.scale
         unselectedBoxLayer.shouldRasterize = true
         unselectedBoxLayer.actions = newActions
@@ -64,7 +64,7 @@ internal class M13CheckboxSpiralController: M13CheckboxController {
         unselectedBoxLayer.fillColor = nil
         
         // Setup the selected box layer.
-        selectedBoxLayer.lineCap = .round
+        selectedBoxLayer.lineCap = CAShapeLayerLineCap.round
         selectedBoxLayer.rasterizationScale = UIScreen.main.scale
         selectedBoxLayer.shouldRasterize = true
         selectedBoxLayer.actions = newActions
@@ -73,8 +73,8 @@ internal class M13CheckboxSpiralController: M13CheckboxController {
         selectedBoxLayer.fillColor = nil
         
         // Setup the checkmark layer.
-        markLayer.lineCap = .round
-        markLayer.lineJoin = .round
+        markLayer.lineCap = CAShapeLayerLineCap.round
+        markLayer.lineJoin = CAShapeLayerLineJoin.round
         markLayer.rasterizationScale = UIScreen.main.scale
         markLayer.shouldRasterize = true
         markLayer.actions = newActions
@@ -107,19 +107,19 @@ internal class M13CheckboxSpiralController: M13CheckboxController {
             markLayer.path = pathGenerator.pathForLongMark(fromState)?.reversing().cgPath
             
             let checkMorphAnimation = animationGenerator.morphAnimation(pathGenerator.pathForMark(fromState)?.reversing(), toPath: pathGenerator.pathForLongMark(fromState)?.reversing())
-            checkMorphAnimation.fillMode = .backwards
+            checkMorphAnimation.fillMode = CAMediaTimingFillMode.backwards
             checkMorphAnimation.duration = checkMorphAnimation.duration / 4.0
-            checkMorphAnimation.timingFunction = CAMediaTimingFunction(name: .easeIn)
+            checkMorphAnimation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeIn)
             
             let checkStrokeAnimation = animationGenerator.strokeAnimation(true)
             checkStrokeAnimation.beginTime = CACurrentMediaTime() + checkMorphAnimation.duration
             checkStrokeAnimation.duration = checkStrokeAnimation.duration / 4.0
-            checkStrokeAnimation.timingFunction = CAMediaTimingFunction(name: .linear)
+            checkStrokeAnimation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.linear)
             
             let boxStrokeAnimation = animationGenerator.strokeAnimation(true)
             boxStrokeAnimation.beginTime = CACurrentMediaTime() + checkMorphAnimation.duration + checkStrokeAnimation.duration
             boxStrokeAnimation.duration = boxStrokeAnimation.duration / 2.0
-            boxStrokeAnimation.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            boxStrokeAnimation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeOut)
             
             let quickOpacityAnimation = animationGenerator.quickOpacityAnimation(true)
             
@@ -152,7 +152,7 @@ internal class M13CheckboxSpiralController: M13CheckboxController {
             
             let boxStrokeAnimation = animationGenerator.strokeAnimation(false)
             boxStrokeAnimation.duration = boxStrokeAnimation.duration / 2.0
-            boxStrokeAnimation.timingFunction = CAMediaTimingFunction(name: .easeIn)
+            boxStrokeAnimation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeIn)
             
             let checkQuickOpacityAnimation = animationGenerator.quickOpacityAnimation(false)
             checkQuickOpacityAnimation.duration = 0.001
@@ -160,13 +160,13 @@ internal class M13CheckboxSpiralController: M13CheckboxController {
             
             let checkStrokeAnimation = animationGenerator.strokeAnimation(false)
             checkStrokeAnimation.duration = checkStrokeAnimation.duration / 4.0
-            checkStrokeAnimation.timingFunction = CAMediaTimingFunction(name: .linear)
-            checkStrokeAnimation.fillMode = .forwards
+            checkStrokeAnimation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.linear)
+            checkStrokeAnimation.fillMode = CAMediaTimingFillMode.forwards
             checkStrokeAnimation.beginTime = CACurrentMediaTime() + boxStrokeAnimation.duration
             
             let checkMorphAnimation = animationGenerator.morphAnimation(pathGenerator.pathForLongMark(toState)?.reversing(), toPath: pathGenerator.pathForMark(toState)?.reversing())
             checkMorphAnimation.duration = checkMorphAnimation.duration / 4.0
-            checkMorphAnimation.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            checkMorphAnimation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeOut)
             checkMorphAnimation.beginTime = CACurrentMediaTime() + boxStrokeAnimation.duration + checkStrokeAnimation.duration
             
             CATransaction.begin()

--- a/Sources/Managers/M13CheckboxStrokeController.swift
+++ b/Sources/Managers/M13CheckboxStrokeController.swift
@@ -51,7 +51,7 @@ internal class M13CheckboxStrokeController: M13CheckboxController {
         ]
         
         // Setup the unselected box layer
-        unselectedBoxLayer.lineCap = .round
+        unselectedBoxLayer.lineCap = CAShapeLayerLineCap.round
         unselectedBoxLayer.rasterizationScale = UIScreen.main.scale
         unselectedBoxLayer.shouldRasterize = true
         unselectedBoxLayer.actions = newActions
@@ -62,7 +62,7 @@ internal class M13CheckboxStrokeController: M13CheckboxController {
         unselectedBoxLayer.fillColor = nil
         
         // Setup the selected box layer.
-        selectedBoxLayer.lineCap = .round
+        selectedBoxLayer.lineCap = CAShapeLayerLineCap.round
         selectedBoxLayer.rasterizationScale = UIScreen.main.scale
         selectedBoxLayer.shouldRasterize = true
         selectedBoxLayer.actions = newActions
@@ -71,8 +71,8 @@ internal class M13CheckboxStrokeController: M13CheckboxController {
         selectedBoxLayer.fillColor = nil
         
         // Setup the checkmark layer.
-        markLayer.lineCap = .round
-        markLayer.lineJoin = .round
+        markLayer.lineCap = CAShapeLayerLineCap.round
+        markLayer.lineJoin = CAShapeLayerLineJoin.round
         markLayer.rasterizationScale = UIScreen.main.scale
         markLayer.shouldRasterize = true
         markLayer.actions = newActions

--- a/Sources/SwiftSupport.swift
+++ b/Sources/SwiftSupport.swift
@@ -1,0 +1,29 @@
+//
+//  Created by David Jennes on 7/10/18.
+//  Copyright © 2018 M13Checkbox. All rights reserved.
+//
+
+import UIKit
+
+/// Swift < 4.2 support
+#if !(swift(>=4.2))
+enum CAMediaTimingFillMode {
+    static let backwards = kCAFillModeBackwards
+    static let forwards = kCAFillModeForwards
+}
+
+enum CAMediaTimingFunctionName {
+    static let linear = kCAMediaTimingFunctionLinear
+    static let easeIn = kCAMediaTimingFunctionEaseIn
+    static let easeOut = kCAMediaTimingFunctionEaseOut
+    static let easeInEaseOut = kCAMediaTimingFunctionEaseInEaseOut
+}
+
+enum CAShapeLayerLineCap {
+    static let round = kCALineCapRound
+}
+
+enum CAShapeLayerLineJoin {
+    static let round = kCALineJoinRound
+}
+#endif


### PR DESCRIPTION
The current Swift 4.2 branch won't work for users who are using Xcode 9 and Swift 4.1 (or older).

With this PR, the branch could be merged into master so that everyone can just use the master branch again, independent of their Swift & Xcode version.