### PR TITLE
unowned should be replaced by weak

### DIFF
--- a/Sources/Managers/M13CheckboxStrokeController.swift
+++ b/Sources/Managers/M13CheckboxStrokeController.swift
@@ -123,8 +123,8 @@ internal class M13CheckboxStrokeController: M13CheckboxController {
             let quickOpacityAnimation = animationGenerator.quickOpacityAnimation(false)
             
             CATransaction.begin()
-            CATransaction.setCompletionBlock({ [unowned self] () -> Void in
-                self.resetLayersForState(self.state)
+            CATransaction.setCompletionBlock({ [weak self] () -> Void in
+                self?.resetLayersForState(self?.state)
                 completion?()
                 })
             


### PR DESCRIPTION
Hi

I am using the state change animation and while resetting layers, because of unowned self, we are getting crash. It should be weak self. Similarly, we have to make changes to other controllers too. 
If you think this is right please do merge.