### PR TITLE
Update unowned references to weak to fix crashes

### DIFF
--- a/Sources/Managers/M13CheckboxStrokeController.swift
+++ b/Sources/Managers/M13CheckboxStrokeController.swift
@@ -105,7 +105,7 @@ internal class M13CheckboxStrokeController: M13CheckboxController {
             let quickOpacityAnimation = animationGenerator.quickOpacityAnimation(true)
             
             CATransaction.begin()
-            CATransaction.setCompletionBlock({ [unowned self] () -> Void in
+            CATransaction.setCompletionBlock({ [weak self] () -> Void in
                 self.resetLayersForState(self.state)
                 completion?()
                 })
@@ -141,7 +141,7 @@ internal class M13CheckboxStrokeController: M13CheckboxController {
             let morphAnimation = animationGenerator.morphAnimation(fromPath, toPath: toPath)
             
             CATransaction.begin()
-            CATransaction.setCompletionBlock({ [unowned self] () -> Void in
+            CATransaction.setCompletionBlock({ [weak self] () -> Void in
                 self.resetLayersForState(self.state)
                 completion?()
                 })

--- a/Sources/Managers/M13CheckboxStrokeController.swift
+++ b/Sources/Managers/M13CheckboxStrokeController.swift
@@ -106,7 +106,7 @@ internal class M13CheckboxStrokeController: M13CheckboxController {
             
             CATransaction.begin()
             CATransaction.setCompletionBlock({ [weak self] () -> Void in
-                self.resetLayersForState(self.state)
+                self?.resetLayersForState(self?.state)
                 completion?()
                 })
             
@@ -142,7 +142,7 @@ internal class M13CheckboxStrokeController: M13CheckboxController {
             
             CATransaction.begin()
             CATransaction.setCompletionBlock({ [weak self] () -> Void in
-                self.resetLayersForState(self.state)
+                self?.resetLayersForState(self?.state)
                 completion?()
                 })
             


### PR DESCRIPTION
change unowned references to weak (results in crashes in some instances)