### PR TITLE
Bugfix: unowned self crash

### DIFF
--- a/Sources/Managers/M13CheckboxBounceController.swift
+++ b/Sources/Managers/M13CheckboxBounceController.swift
@@ -171,8 +171,8 @@ internal class M13CheckboxBounceController: M13CheckboxController {
             let morphAnimation = animationGenerator.morphAnimation(fromPath, toPath: toPath)
             
             CATransaction.begin()
-            CATransaction.setCompletionBlock({ [unowned self] () -> Void in
-                self.resetLayersForState(self.state)
+            CATransaction.setCompletionBlock({ [weak self] () -> Void in
+                self?.resetLayersForState(self?.state)
                 completion?()
                 })
             

--- a/Sources/Managers/M13CheckboxDotController.swift
+++ b/Sources/Managers/M13CheckboxDotController.swift
@@ -174,8 +174,8 @@ internal class M13CheckboxDotController: M13CheckboxController {
             let morphAnimation = animationGenerator.morphAnimation(fromPath, toPath: toPath)
             
             CATransaction.begin()
-            CATransaction.setCompletionBlock({ [unowned self] () -> Void in
-                self.resetLayersForState(self.state)
+            CATransaction.setCompletionBlock({ [weak self] () -> Void in
+                self?.resetLayersForState(self?.state)
                 completion?()
                 })
             

--- a/Sources/Managers/M13CheckboxExpandController.swift
+++ b/Sources/Managers/M13CheckboxExpandController.swift
@@ -163,8 +163,8 @@ internal class M13CheckboxExpandController: M13CheckboxController {
             let morphAnimation = animationGenerator.morphAnimation(fromPath, toPath: toPath)
             
             CATransaction.begin()
-            CATransaction.setCompletionBlock({ [unowned self] () -> Void in
-                self.resetLayersForState(self.state)
+            CATransaction.setCompletionBlock({ [weak self] () -> Void in
+                self?.resetLayersForState(self?.state)
                 completion?()
                 })
             

--- a/Sources/Managers/M13CheckboxFadeController.swift
+++ b/Sources/Managers/M13CheckboxFadeController.swift
@@ -163,8 +163,8 @@ internal class M13CheckboxFadeController: M13CheckboxController {
             let morphAnimation = animationGenerator.morphAnimation(fromPath, toPath: toPath)
             
             CATransaction.begin()
-            CATransaction.setCompletionBlock({ [unowned self] () -> Void in
-                self.resetLayersForState(self.state)
+            CATransaction.setCompletionBlock({ [weak self] () -> Void in
+                self?.resetLayersForState(self?.state)
                 completion?()
                 })
             

--- a/Sources/Managers/M13CheckboxFillController.swift
+++ b/Sources/Managers/M13CheckboxFillController.swift
@@ -142,8 +142,8 @@ internal class M13CheckboxFillController: M13CheckboxController {
             let morphAnimation = animationGenerator.morphAnimation(fromPath, toPath: toPath)
             
             CATransaction.begin()
-            CATransaction.setCompletionBlock({ [unowned self] () -> Void in
-                self.resetLayersForState(self.state)
+            CATransaction.setCompletionBlock({ [weak self] () -> Void in
+                self?.resetLayersForState(self?.state)
                 completion?()
                 })
             

--- a/Sources/Managers/M13CheckboxFlatController.swift
+++ b/Sources/Managers/M13CheckboxFlatController.swift
@@ -181,8 +181,8 @@ internal class M13CheckboxFlatController: M13CheckboxController {
             let morphAnimation = animationGenerator.morphAnimation(fromPath, toPath: toPath)
             
             CATransaction.begin()
-            CATransaction.setCompletionBlock({ [unowned self] () -> Void in
-                self.resetLayersForState(self.state)
+            CATransaction.setCompletionBlock({ [weak self] () -> Void in
+                self?.resetLayersForState(self?.state)
                 completion?()
                 })
             

--- a/Sources/Managers/M13CheckboxSpiralController.swift
+++ b/Sources/Managers/M13CheckboxSpiralController.swift
@@ -193,8 +193,8 @@ internal class M13CheckboxSpiralController: M13CheckboxController {
             let morphAnimation = animationGenerator.morphAnimation(fromPath, toPath: toPath)
             
             CATransaction.begin()
-            CATransaction.setCompletionBlock({ [unowned self] () -> Void in
-                self.resetLayersForState(self.state)
+            CATransaction.setCompletionBlock({ [weak self] () -> Void in
+                self?.resetLayersForState(self?.state)
                 completion?()
                 })
             

--- a/Sources/Managers/M13CheckboxStrokeController.swift
+++ b/Sources/Managers/M13CheckboxStrokeController.swift
@@ -105,8 +105,8 @@ internal class M13CheckboxStrokeController: M13CheckboxController {
             let quickOpacityAnimation = animationGenerator.quickOpacityAnimation(true)
             
             CATransaction.begin()
-            CATransaction.setCompletionBlock({ [unowned self] () -> Void in
-                self.resetLayersForState(self.state)
+            CATransaction.setCompletionBlock({ [weak self] () -> Void in
+                self?.resetLayersForState(self?.state)
                 completion?()
                 })
             
@@ -141,8 +141,8 @@ internal class M13CheckboxStrokeController: M13CheckboxController {
             let morphAnimation = animationGenerator.morphAnimation(fromPath, toPath: toPath)
             
             CATransaction.begin()
-            CATransaction.setCompletionBlock({ [unowned self] () -> Void in
-                self.resetLayersForState(self.state)
+            CATransaction.setCompletionBlock({ [weak self] () -> Void in
+                self?.resetLayersForState(self?.state)
                 completion?()
                 })
             


### PR DESCRIPTION
Unowned self references cause a crash when trying to perform an animation while/after the checkbox is (being) deallocated. Changing them to weak self references fixes this.