### PR TITLE
Explicitly mark function as @objc compatible

### DIFF
--- a/Sources/M13Checkbox.swift
+++ b/Sources/M13Checkbox.swift
@@ -316,7 +316,7 @@ open class M13Checkbox: UIControl {
      - parameter animated: Whether or not to animate the change. Defaults to false.
      - note: If the checkbox is mixed, it will return to the unchecked state.
      */
-    open func toggleCheckState(_ animated: Bool = false) {
+    @objc open func toggleCheckState(_ animated: Bool = false) {
         switch checkState {
         case .checked:
             setCheckState(.unchecked, animated: animated)


### PR DESCRIPTION
My understanding is that you do not want to explicitly support Objc. However I realized that a few methods are able to be bridged successfully but are not necessarily automatic.

Would you consider at least marking this method @Objc compatible?